### PR TITLE
Allow parsing of javascript object (ex: when props have no quotes aro…

### DIFF
--- a/src/utilities/extractJson.js
+++ b/src/utilities/extractJson.js
@@ -2,16 +2,18 @@
 
 type ExtractJsonConfigurationType = {|
   // eslint-disable-next-line flowtype/no-weak-types
-  +parser?: (input: string) => any
+  +parser?: (input: string) => any,
+  +stringifier?: (input: object) => any
 |};
 
 const closeCharacterMap = {
   '"': '"',
-  '[': ']',
-  '{': '}'
+  "[": "]",
+  "{": "}"
 };
 
 const defaultParser = JSON.parse.bind(JSON);
+const defaultStringifier = JSON.stringify.bind(JSON);
 
 /**
  * Extracts JSON entities from an arbitrary string.
@@ -19,6 +21,7 @@ const defaultParser = JSON.parse.bind(JSON);
 // eslint-disable-next-line flowtype/no-weak-types
 export default (subject: string, configuration?: ExtractJsonConfigurationType): $ReadOnlyArray<any> => {
   const parser = configuration && configuration.parser ? configuration.parser : defaultParser;
+  const stringifier = configuration && configuration.stringifier ? configuration.stringifier : defaultStringifier;
 
   const foundObjects = [];
 
@@ -43,18 +46,22 @@ export default (subject: string, configuration?: ExtractJsonConfigurationType): 
     let haystack = offsetSubject.slice(startIndex);
 
     while (haystack.length) {
+      const addResult = result => {
+        foundObjects.push(result);
+        subjectOffset += startIndex + haystack.length;
+        rule.lastIndex = 0;
+      };
+
       try {
         const result = parser(haystack);
-
-        foundObjects.push(result);
-
-        subjectOffset += startIndex + haystack.length;
-
-        rule.lastIndex = 0;
-
+        addResult(result);
         break;
       } catch (error) {
-        //
+        try {
+          const result = parser(stringifier(eval(`(() => { return ${haystack} })()`)));
+          addResult(result);
+          break;
+        } catch (error) {}
       }
 
       const offsetIndex = haystack.slice(0, -1).lastIndexOf(closeCharacter) + 1;


### PR DESCRIPTION
I've used your code in one of my project and felt like you would appreciate the update.

If you've got the following code in a string (html page) :
```text
var g = {
        prop: "value"
      };
```

It wouldn't be parsed by JSON.parse so I added an extra solution if the JSON.parse fails with an eval() which returns the object which is then stringified and parsed.

Hope you like it ;)

---
So for the example, it will return:
```js
[
  {
    "prop": "value"
  }
]
```